### PR TITLE
Major refactor for enchantments

### DIFF
--- a/src/main/java/com/github/mcri/Enchantments/BaneofAquaticsEnchant.java
+++ b/src/main/java/com/github/mcri/Enchantments/BaneofAquaticsEnchant.java
@@ -1,4 +1,4 @@
-package com.github.mcri.Enchantments;
+package com.github.mcri.enchantments;
 
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentTarget;
@@ -10,15 +10,8 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.TridentItem;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 
 public class BaneofAquaticsEnchant extends Enchantment {
-    public static final BaneofAquaticsEnchant BANEAQUATICS = new BaneofAquaticsEnchant();
-
-    public static void Register() {
-        Registry.register(Registry.ENCHANTMENT, new Identifier("mcri", "bane_aquatics"), BANEAQUATICS);
-    }
 
     public BaneofAquaticsEnchant() {
         super(Enchantment.Rarity.RARE, EnchantmentTarget.WEAPON, new EquipmentSlot[] { EquipmentSlot.MAINHAND });
@@ -38,10 +31,10 @@ public class BaneofAquaticsEnchant extends Enchantment {
     @Override
     protected boolean canAccept(Enchantment other) {
         if (other == Enchantments.BANE_OF_ARTHROPODS ||
-                other == BaneofSwinesEnchant.BANESWINES ||
-                other == BaneofVillagersEnchant.BANEVILLAGERS ||
-                other == BaneofEnderEnchant.BANEENDER ||
-                other == BaneofIllagersEnchant.BANEILLAGERS) {
+                other == ModEnchantments.BANE_SWINES ||
+                other == ModEnchantments.BANE_VILLAGERS ||
+                other == ModEnchantments.BANE_ENDER ||
+                other == ModEnchantments.BANE_ILLAGERS) {
             return false;
         }
         return true;

--- a/src/main/java/com/github/mcri/Enchantments/BaneofEnderEnchant.java
+++ b/src/main/java/com/github/mcri/Enchantments/BaneofEnderEnchant.java
@@ -1,4 +1,4 @@
-package com.github.mcri.Enchantments;
+package com.github.mcri.enchantments;
 
 import com.github.mcri.StatusEffects.BaneofEnderEffect;
 
@@ -22,15 +22,8 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.TridentItem;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 
 public class BaneofEnderEnchant extends Enchantment {
-    public static final BaneofEnderEnchant BANEENDER = new BaneofEnderEnchant();
-
-    public static void Register() {
-        Registry.register(Registry.ENCHANTMENT, new Identifier("mcri", "bane_ender"), BANEENDER);
-    }
 
     public BaneofEnderEnchant() {
         super(Enchantment.Rarity.RARE, EnchantmentTarget.WEAPON, new EquipmentSlot[] { EquipmentSlot.MAINHAND });
@@ -50,10 +43,10 @@ public class BaneofEnderEnchant extends Enchantment {
     @Override
     protected boolean canAccept(Enchantment other) {
         if (other == Enchantments.BANE_OF_ARTHROPODS ||
-                other == BaneofAquaticsEnchant.BANEAQUATICS ||
-                other == BaneofVillagersEnchant.BANEVILLAGERS ||
-                other == BaneofSwinesEnchant.BANESWINES ||
-                other == BaneofIllagersEnchant.BANEILLAGERS) {
+                other == ModEnchantments.BANE_AQUATICS ||
+                other == ModEnchantments.BANE_VILLAGERS ||
+                other == ModEnchantments.BANE_SWINES ||
+                other == ModEnchantments.BANE_ILLAGERS) {
             return false;
         }
         return true;

--- a/src/main/java/com/github/mcri/Enchantments/BaneofIllagersEnchant.java
+++ b/src/main/java/com/github/mcri/Enchantments/BaneofIllagersEnchant.java
@@ -1,4 +1,4 @@
-package com.github.mcri.Enchantments;
+package com.github.mcri.enchantments;
 
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -22,15 +22,8 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.TridentItem;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 
 public class BaneofIllagersEnchant extends Enchantment {
-    public static final BaneofIllagersEnchant BANEILLAGERS = new BaneofIllagersEnchant();
-
-    public static void Register() {
-        Registry.register(Registry.ENCHANTMENT, new Identifier("mcri", "bane_illagers"), BANEILLAGERS);
-    }
 
     public BaneofIllagersEnchant() {
         super(Enchantment.Rarity.RARE, EnchantmentTarget.WEAPON, new EquipmentSlot[] { EquipmentSlot.MAINHAND });
@@ -50,10 +43,10 @@ public class BaneofIllagersEnchant extends Enchantment {
     @Override
     protected boolean canAccept(Enchantment other) {
         if (other == Enchantments.BANE_OF_ARTHROPODS ||
-                other == BaneofAquaticsEnchant.BANEAQUATICS ||
-                other == BaneofVillagersEnchant.BANEVILLAGERS ||
-                other == BaneofSwinesEnchant.BANESWINES ||
-                other == BaneofEnderEnchant.BANEENDER) {
+                other == ModEnchantments.BANE_AQUATICS ||
+                other == ModEnchantments.BANE_VILLAGERS ||
+                other == ModEnchantments.BANE_SWINES ||
+                other == ModEnchantments.BANE_ENDER) {
             return false;
         }
         return true;

--- a/src/main/java/com/github/mcri/Enchantments/BaneofSwinesEnchant.java
+++ b/src/main/java/com/github/mcri/Enchantments/BaneofSwinesEnchant.java
@@ -1,4 +1,4 @@
-package com.github.mcri.Enchantments;
+package com.github.mcri.enchantments;
 
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -21,15 +21,8 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.TridentItem;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 
 public class BaneofSwinesEnchant extends Enchantment {
-    public static final BaneofSwinesEnchant BANESWINES = new BaneofSwinesEnchant();
-
-    public static void Register() {
-        Registry.register(Registry.ENCHANTMENT, new Identifier("mcri", "bane_swines"), BANESWINES);
-    }
 
     public BaneofSwinesEnchant() {
         super(Enchantment.Rarity.RARE, EnchantmentTarget.WEAPON, new EquipmentSlot[] { EquipmentSlot.MAINHAND });
@@ -49,10 +42,10 @@ public class BaneofSwinesEnchant extends Enchantment {
     @Override
     protected boolean canAccept(Enchantment other) {
         if (other == Enchantments.BANE_OF_ARTHROPODS ||
-                other == BaneofAquaticsEnchant.BANEAQUATICS ||
-                other == BaneofVillagersEnchant.BANEVILLAGERS ||
-                other == BaneofEnderEnchant.BANEENDER ||
-                other == BaneofIllagersEnchant.BANEILLAGERS) {
+                other == ModEnchantments.BANE_AQUATICS ||
+                other == ModEnchantments.BANE_VILLAGERS ||
+                other == ModEnchantments.BANE_ENDER ||
+                other == ModEnchantments.BANE_ILLAGERS) {
             return false;
         }
         return true;

--- a/src/main/java/com/github/mcri/Enchantments/BaneofVillagersEnchant.java
+++ b/src/main/java/com/github/mcri/Enchantments/BaneofVillagersEnchant.java
@@ -1,4 +1,4 @@
-package com.github.mcri.Enchantments;
+package com.github.mcri.enchantments;
 
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -18,16 +18,9 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.TridentItem;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 
 public class BaneofVillagersEnchant extends Enchantment {
-    public static final BaneofVillagersEnchant BANEVILLAGERS = new BaneofVillagersEnchant();
-
-    public static void Register() {
-        Registry.register(Registry.ENCHANTMENT, new Identifier("mcri", "bane_villagers"), BANEVILLAGERS);
-    }
-
+    
     public BaneofVillagersEnchant() {
         super(Enchantment.Rarity.RARE, EnchantmentTarget.WEAPON, new EquipmentSlot[] { EquipmentSlot.MAINHAND });
     }
@@ -46,10 +39,10 @@ public class BaneofVillagersEnchant extends Enchantment {
     @Override
     protected boolean canAccept(Enchantment other) {
         if (other == Enchantments.BANE_OF_ARTHROPODS ||
-                other == BaneofAquaticsEnchant.BANEAQUATICS ||
-                other == BaneofIllagersEnchant.BANEILLAGERS ||
-                other == BaneofSwinesEnchant.BANESWINES ||
-                other == BaneofEnderEnchant.BANEENDER) {
+                other == ModEnchantments.BANE_AQUATICS ||
+                other == ModEnchantments.BANE_ILLAGERS ||
+                other == ModEnchantments.BANE_SWINES ||
+                other == ModEnchantments.BANE_ENDER) {
             return false;
         }
         return true;

--- a/src/main/java/com/github/mcri/Enchantments/ClearSkiesEnchant.java
+++ b/src/main/java/com/github/mcri/Enchantments/ClearSkiesEnchant.java
@@ -1,4 +1,4 @@
-package com.github.mcri.Enchantments;
+package com.github.mcri.enchantments;
 
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -14,15 +14,8 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.TridentItem;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 
 public class ClearSkiesEnchant extends Enchantment {
-    public static final ClearSkiesEnchant CLEARSKIES = new ClearSkiesEnchant();
-
-    public static void Register() {
-        Registry.register(Registry.ENCHANTMENT, new Identifier("mcri", "clear_skies"), CLEARSKIES);
-    }
 
     public ClearSkiesEnchant() {
         super(Enchantment.Rarity.RARE, EnchantmentTarget.WEAPON, new EquipmentSlot[] { EquipmentSlot.MAINHAND });
@@ -41,9 +34,9 @@ public class ClearSkiesEnchant extends Enchantment {
 
     @Override
     protected boolean canAccept(Enchantment other) {
-        if (other == NoSkiesEnchant.NOSKIES ||
-                other == DarkSkiesEnchant.DARKSKIES ||
-                other == StormySkiesEnchant.STORMYSKIES) {
+        if (other == ModEnchantments.NO_SKIES ||
+                other == ModEnchantments.DARK_SKIES ||
+                other == ModEnchantments.STORMY_SKIES) {
             return false;
         }
         return true;

--- a/src/main/java/com/github/mcri/Enchantments/DarkSkiesEnchant.java
+++ b/src/main/java/com/github/mcri/Enchantments/DarkSkiesEnchant.java
@@ -1,4 +1,4 @@
-package com.github.mcri.Enchantments;
+package com.github.mcri.enchantments;
 
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -14,15 +14,8 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.TridentItem;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 
 public class DarkSkiesEnchant extends Enchantment {
-    public static final DarkSkiesEnchant DARKSKIES = new DarkSkiesEnchant();
-
-    public static void Register() {
-        Registry.register(Registry.ENCHANTMENT, new Identifier("mcri", "dark_skies"), DARKSKIES);
-    }
 
     public DarkSkiesEnchant() {
         super(Enchantment.Rarity.RARE, EnchantmentTarget.WEAPON, new EquipmentSlot[] { EquipmentSlot.MAINHAND });
@@ -41,9 +34,9 @@ public class DarkSkiesEnchant extends Enchantment {
 
     @Override
     protected boolean canAccept(Enchantment other) {
-        if (other == NoSkiesEnchant.NOSKIES ||
-                other == ClearSkiesEnchant.CLEARSKIES ||
-                other == StormySkiesEnchant.STORMYSKIES) {
+        if (other == ModEnchantments.NO_SKIES ||
+                other == ModEnchantments.CLEAR_SKIES ||
+                other == ModEnchantments.STORMY_SKIES) {
             return false;
         }
         return true;

--- a/src/main/java/com/github/mcri/Enchantments/FrostbiteEnchant.java
+++ b/src/main/java/com/github/mcri/Enchantments/FrostbiteEnchant.java
@@ -1,4 +1,4 @@
-package com.github.mcri.Enchantments;
+package com.github.mcri.enchantments;
 
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentTarget;
@@ -14,15 +14,8 @@ import net.minecraft.item.SwordItem;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.server.world.ServerWorld;
 import com.github.mcri.StatusEffects.FrozenEffect;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 
 public class FrostbiteEnchant extends Enchantment {
-    public static final FrostbiteEnchant FROSTBITE = new FrostbiteEnchant();
-
-    public static void Register() {
-        Registry.register(Registry.ENCHANTMENT, new Identifier("mcri", "frostbite"), FROSTBITE);
-    }
 
     public FrostbiteEnchant() {
         super(Enchantment.Rarity.RARE, EnchantmentTarget.WEAPON, new EquipmentSlot[] { EquipmentSlot.MAINHAND });
@@ -39,7 +32,7 @@ public class FrostbiteEnchant extends Enchantment {
 
     @Override
     protected boolean canAccept(Enchantment other) {
-        if (other == Enchantments.FIRE_ASPECT || other == PoisonAspectEnchant.POISON || other == WitheringEnchant.WITHERING) {
+        if (other == Enchantments.FIRE_ASPECT || other == ModEnchantments.POISON_ASPECT || other == ModEnchantments.WITHERING) {
             return false;
         }
         return true;

--- a/src/main/java/com/github/mcri/Enchantments/LevitationEnchant.java
+++ b/src/main/java/com/github/mcri/Enchantments/LevitationEnchant.java
@@ -1,4 +1,4 @@
-package com.github.mcri.Enchantments;
+package com.github.mcri.enchantments;
 
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentTarget;
@@ -11,15 +11,8 @@ import net.minecraft.item.AxeItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 
 public class LevitationEnchant extends Enchantment {
-    public static final LevitationEnchant LEVITATION = new LevitationEnchant();
-
-    public static void Register() {
-        Registry.register(Registry.ENCHANTMENT, new Identifier("mcri", "levitation"), LEVITATION);
-    }
 
     public LevitationEnchant() {
         super(Enchantment.Rarity.VERY_RARE, EnchantmentTarget.WEAPON, new EquipmentSlot[] { EquipmentSlot.MAINHAND });

--- a/src/main/java/com/github/mcri/Enchantments/LifeStealEnchant.java
+++ b/src/main/java/com/github/mcri/Enchantments/LifeStealEnchant.java
@@ -1,4 +1,4 @@
-package com.github.mcri.Enchantments;
+package com.github.mcri.enchantments;
 
 import com.github.mcri.IEnchantmentTimoutExt;
 
@@ -12,15 +12,8 @@ import net.minecraft.item.AxeItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.TridentItem;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 
 public class LifeStealEnchant extends Enchantment {
-    public static final LifeStealEnchant LIFESTEAL = new LifeStealEnchant();
-
-    public static void Register() {
-        Registry.register(Registry.ENCHANTMENT, new Identifier("mcri", "life_steal"), LIFESTEAL);
-    }
 
     public LifeStealEnchant() {
         super(Enchantment.Rarity.VERY_RARE, EnchantmentTarget.WEAPON, new EquipmentSlot[] { EquipmentSlot.MAINHAND });

--- a/src/main/java/com/github/mcri/Enchantments/LightningEnchant.java
+++ b/src/main/java/com/github/mcri/Enchantments/LightningEnchant.java
@@ -1,4 +1,4 @@
-package com.github.mcri.Enchantments;
+package com.github.mcri.enchantments;
 
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentTarget;
@@ -8,16 +8,9 @@ import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.SpawnReason;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.registry.Registry;
 
 public class LightningEnchant extends Enchantment {
-    public static final LightningEnchant LIGHTNING = new LightningEnchant();
-
-    public static void Register() {
-        Registry.register(Registry.ENCHANTMENT, new Identifier("mcri", "lightning"), LIGHTNING);
-    }
 
     public LightningEnchant() {
         super(Enchantment.Rarity.VERY_RARE, EnchantmentTarget.WEAPON, new EquipmentSlot[] { EquipmentSlot.MAINHAND });

--- a/src/main/java/com/github/mcri/Enchantments/ModEnchantments.java
+++ b/src/main/java/com/github/mcri/Enchantments/ModEnchantments.java
@@ -1,0 +1,102 @@
+package com.github.mcri.enchantments;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Set;
+
+import com.github.mcri.MinecraftReimagined;
+
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+public final class ModEnchantments {
+    // Banes
+    public static BaneofAquaticsEnchant BANE_AQUATICS;
+    public static BaneofEnderEnchant BANE_ENDER;
+    public static BaneofIllagersEnchant BANE_ILLAGERS;
+    public static BaneofSwinesEnchant BANE_SWINES;
+    public static BaneofVillagersEnchant BANE_VILLAGERS;
+
+    // Skies
+    public static ClearSkiesEnchant CLEAR_SKIES;
+    public static DarkSkiesEnchant DARK_SKIES;
+    public static NoSkiesEnchant NO_SKIES;
+    public static StormySkiesEnchant STORMY_SKIES;
+
+    // Aspects
+    public static PoisonAspectEnchant POISON_ASPECT;
+    public static WitheringEnchant WITHERING;
+
+    // Other
+    public static FrostbiteEnchant FROSTBITE;
+    public static LevitationEnchant LEVITATION;
+    public static LifeStealEnchant LIFESTEAL;
+    public static LightningEnchant LIGHTNING;
+    public static MountedEnchant MOUNTED;
+
+    /**
+     * Registers all the enchantments that have been registered
+     */
+    public static void registerAll() {
+        Set<String> keys = delayedRegisters.keySet();
+
+        for (Iterator<String> iter = keys.iterator(); iter.hasNext();) {
+            String key = iter.next();
+            Registry.register(Registry.ENCHANTMENT, new Identifier(MinecraftReimagined.MOD_ID, key), delayedRegisters.get(key));
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    // Black magic section below
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+
+    private static HashMap<String, Enchantment> delayedRegisters = new HashMap<String, Enchantment>();
+
+    static {
+        // get all the fields in this class
+        Field[] fields = ModEnchantments.class.getDeclaredFields();
+        for (int i = 0; i < fields.length; ++i) {
+            try {
+                // check that they're static and an enchantment
+                if (!fields[i].canAccess(null) || fields[i].getType().getSuperclass() != Enchantment.class) {
+                    continue;
+                }
+
+                MinecraftReimagined.LOGGER.debug("registering '" + fields[i].getName() + "'");
+
+                // set them to an instance of an object and get ready for delayed registering
+                fields[i].set(null, delayedRegister(fields[i].getName().toLowerCase(), fields[i].getType()));
+            }
+            catch (Exception ex) {
+                MinecraftReimagined.LOGGER.error("Failed to register enchantment '" + fields[i].getName().toLowerCase() + "'");
+            }
+        }
+    }
+
+    /**
+     * sets an enchantment to be registered later
+     * 
+     * @param <T>
+     *            the enchantment type
+     * @param id
+     *            the id of the enchantment
+     * @param type
+     *            the class of the enchantment
+     * @return an instance of the enchantment to be registered later
+     */
+    private static Enchantment delayedRegister(String id, Class<?> type) {
+        try {
+            // create a new instance of the enchantment with the default constructor
+            Enchantment instance = (Enchantment)type.getDeclaredConstructor().newInstance();
+            // register it for future registration
+            delayedRegisters.put(id, instance);
+            return instance;
+        }
+        catch (Exception ex) {
+            MinecraftReimagined.LOGGER.error("Failed to register enchantment '" + id + "' (" + type.getName() + ")");
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/github/mcri/Enchantments/MountedEnchant.java
+++ b/src/main/java/com/github/mcri/Enchantments/MountedEnchant.java
@@ -1,4 +1,4 @@
-package com.github.mcri.Enchantments;
+package com.github.mcri.enchantments;
 
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -19,15 +19,8 @@ import net.minecraft.item.AxeItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 
 public class MountedEnchant extends Enchantment {
-    public static final MountedEnchant MOUNTED = new MountedEnchant();
-
-    public static void Register() {
-        Registry.register(Registry.ENCHANTMENT, new Identifier("mcri", "mounted"), MOUNTED);
-    }
 
     public MountedEnchant() {
         super(Enchantment.Rarity.RARE, EnchantmentTarget.WEAPON, new EquipmentSlot[] { EquipmentSlot.MAINHAND });

--- a/src/main/java/com/github/mcri/Enchantments/NoSkiesEnchant.java
+++ b/src/main/java/com/github/mcri/Enchantments/NoSkiesEnchant.java
@@ -1,4 +1,4 @@
-package com.github.mcri.Enchantments;
+package com.github.mcri.enchantments;
 
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -14,15 +14,8 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.TridentItem;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 
 public class NoSkiesEnchant extends Enchantment {
-    public static final NoSkiesEnchant NOSKIES = new NoSkiesEnchant();
-
-    public static void Register() {
-        Registry.register(Registry.ENCHANTMENT, new Identifier("mcri", "no_skies"), NOSKIES);
-    }
 
     public NoSkiesEnchant() {
         super(Enchantment.Rarity.RARE, EnchantmentTarget.WEAPON, new EquipmentSlot[] { EquipmentSlot.MAINHAND });
@@ -41,9 +34,9 @@ public class NoSkiesEnchant extends Enchantment {
 
     @Override
     protected boolean canAccept(Enchantment other) {
-        if (other == ClearSkiesEnchant.CLEARSKIES ||
-                other == DarkSkiesEnchant.DARKSKIES ||
-                other == StormySkiesEnchant.STORMYSKIES) {
+        if (other == ModEnchantments.CLEAR_SKIES ||
+                other == ModEnchantments.DARK_SKIES ||
+                other == ModEnchantments.STORMY_SKIES) {
             return false;
         }
         return true;

--- a/src/main/java/com/github/mcri/Enchantments/PoisonAspectEnchant.java
+++ b/src/main/java/com/github/mcri/Enchantments/PoisonAspectEnchant.java
@@ -1,4 +1,4 @@
-package com.github.mcri.Enchantments;
+package com.github.mcri.enchantments;
 
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentTarget;
@@ -14,15 +14,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.TridentItem;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 
 public class PoisonAspectEnchant extends Enchantment {
-    public static final PoisonAspectEnchant POISON = new PoisonAspectEnchant();
-
-    public static void Register() {
-        Registry.register(Registry.ENCHANTMENT, new Identifier("mcri", "poison_aspect"), POISON);
-    }
 
     public PoisonAspectEnchant() {
         super(Enchantment.Rarity.VERY_RARE, EnchantmentTarget.WEAPON, new EquipmentSlot[] { EquipmentSlot.MAINHAND });
@@ -44,7 +37,7 @@ public class PoisonAspectEnchant extends Enchantment {
 
     @Override
     protected boolean canAccept(Enchantment other) {
-        if (other == Enchantments.FIRE_ASPECT || other == FrostbiteEnchant.FROSTBITE || other == WitheringEnchant.WITHERING) {
+        if (other == Enchantments.FIRE_ASPECT || other == ModEnchantments.FROSTBITE || other == ModEnchantments.WITHERING) {
             return false;
         }
         return true;

--- a/src/main/java/com/github/mcri/Enchantments/StormySkiesEnchant.java
+++ b/src/main/java/com/github/mcri/Enchantments/StormySkiesEnchant.java
@@ -1,4 +1,4 @@
-package com.github.mcri.Enchantments;
+package com.github.mcri.enchantments;
 
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -14,15 +14,8 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.TridentItem;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 
 public class StormySkiesEnchant extends Enchantment {
-    public static final StormySkiesEnchant STORMYSKIES = new StormySkiesEnchant();
-
-    public static void Register() {
-        Registry.register(Registry.ENCHANTMENT, new Identifier("mcri", "stormy_skies"), STORMYSKIES);
-    }
 
     public StormySkiesEnchant() {
         super(Enchantment.Rarity.RARE, EnchantmentTarget.WEAPON, new EquipmentSlot[] { EquipmentSlot.MAINHAND });
@@ -41,9 +34,9 @@ public class StormySkiesEnchant extends Enchantment {
 
     @Override
     protected boolean canAccept(Enchantment other) {
-        if (other == NoSkiesEnchant.NOSKIES ||
-                other == DarkSkiesEnchant.DARKSKIES ||
-                other == ClearSkiesEnchant.CLEARSKIES) {
+        if (other == ModEnchantments.NO_SKIES ||
+                other == ModEnchantments.DARK_SKIES ||
+                other == ModEnchantments.CLEAR_SKIES) {
             return false;
         }
         return true;

--- a/src/main/java/com/github/mcri/Enchantments/WitheringEnchant.java
+++ b/src/main/java/com/github/mcri/Enchantments/WitheringEnchant.java
@@ -1,4 +1,4 @@
-package com.github.mcri.Enchantments;
+package com.github.mcri.enchantments;
 
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentTarget;
@@ -12,15 +12,8 @@ import net.minecraft.item.AxeItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.TridentItem;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 
 public class WitheringEnchant extends Enchantment {
-    public static final WitheringEnchant WITHERING = new WitheringEnchant();
-
-    public static void Register() {
-        Registry.register(Registry.ENCHANTMENT, new Identifier("mcri", "withering"), WITHERING);
-    }
 
     public WitheringEnchant() {
         super(Enchantment.Rarity.VERY_RARE, EnchantmentTarget.WEAPON, new EquipmentSlot[] { EquipmentSlot.MAINHAND });
@@ -42,7 +35,7 @@ public class WitheringEnchant extends Enchantment {
 
     @Override
     protected boolean canAccept(Enchantment other) {
-        if (other == Enchantments.FIRE_ASPECT || other == PoisonAspectEnchant.POISON || other == FrostbiteEnchant.FROSTBITE) {
+        if (other == Enchantments.FIRE_ASPECT || other == ModEnchantments.POISON_ASPECT || other == ModEnchantments.FROSTBITE) {
             return false;
         }
         return true;

--- a/src/main/java/com/github/mcri/MinecraftReimagined.java
+++ b/src/main/java/com/github/mcri/MinecraftReimagined.java
@@ -5,9 +5,9 @@ import net.fabricmc.api.ModInitializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.mcri.Enchantments.*;
 import com.github.mcri.StatusEffects.*;
 import com.github.mcri.block.*;
+import com.github.mcri.enchantments.ModEnchantments;
 import com.github.mcri.Items.ModItems;
 
 public class MinecraftReimagined implements ModInitializer {
@@ -24,26 +24,10 @@ public class MinecraftReimagined implements ModInitializer {
 		// This code runs as soon as Minecraft is in a mod-load-ready state.
 		// However, some things (like resources) may still be uninitialized.
 		// Proceed with mild caution.
+		LOGGER.info("Initializing...");
 
 		ModItems.registerItems();
-
-		LOGGER.info("Initializing...");
-		// Enchantments
-		FrostbiteEnchant.Register();
-		LifeStealEnchant.Register();
-		PoisonAspectEnchant.Register();
-		WitheringEnchant.Register();
-		MountedEnchant.Register();
-		LevitationEnchant.Register();
-		BaneofAquaticsEnchant.Register();
-		BaneofEnderEnchant.Register();
-		BaneofSwinesEnchant.Register();
-		BaneofVillagersEnchant.Register();
-		BaneofIllagersEnchant.Register();
-		ClearSkiesEnchant.Register();
-		NoSkiesEnchant.Register();
-		DarkSkiesEnchant.Register();
-		StormySkiesEnchant.Register();
+		ModEnchantments.registerAll();
 
 		// Status effects
 		FrozenEffect.Register();

--- a/src/main/java/com/github/mcri/Mixins/AnvilRemoveMaxLevelMixin.java
+++ b/src/main/java/com/github/mcri/Mixins/AnvilRemoveMaxLevelMixin.java
@@ -108,7 +108,7 @@ public abstract class AnvilRemoveMaxLevelMixin extends ForgingScreenHandler {
                     Map<Enchantment, Integer> rightEnchantLevels = EnchantmentHelper.get(inputStackRight);
                     boolean hasCombinableEnchant = false;
                     boolean hasUncombinableEnchant = false;
-                    Iterator enchantIter = rightEnchantLevels.keySet().iterator();
+                    Iterator<Enchantment> enchantIter = rightEnchantLevels.keySet().iterator();
 
                     label155: while (true) {
                         Enchantment enchantment;
@@ -137,7 +137,7 @@ public abstract class AnvilRemoveMaxLevelMixin extends ForgingScreenHandler {
                             canCombine = true;
                         }
 
-                        Iterator var17 = leftEnchantLevels.keySet().iterator();
+                        Iterator<Enchantment> var17 = leftEnchantLevels.keySet().iterator();
 
                         while (var17.hasNext()) {
                             Enchantment enchantment2 = (Enchantment) var17.next();


### PR DESCRIPTION
Made it so all you have to do to register an enchantment is to put a static declaration of the enchantment in the "ModEnchantments" class

the id will be the lowercased name of the field.

EX:
```java
 public static BaneofAquaticsEnchant BANE_AQUATICS;
```
would be registered as "mcri:bane_aquatics"
